### PR TITLE
fix:remove escapeHtml from short_content in card.phtml

### DIFF
--- a/view/frontend/templates/post/card.phtml
+++ b/view/frontend/templates/post/card.phtml
@@ -54,7 +54,7 @@ $authorUrl = $viewModel->getAuthorUrl($post);
         <?php endif; ?>
     </p>
     <?php if ($excerpt !== ''): ?>
-        <p class="mageos-blog-card__excerpt"><?= $escaper->escapeHtml($excerpt); ?></p>
+        <p class="mageos-blog-card__excerpt"><?= /** @noEscape */ (string) $excerpt; ?></p>
     <?php endif; ?>
     <p class="mageos-blog-card__cta">
         <a href="<?= $escaper->escapeUrl($postUrl); ?>"><?= $escaper->escapeHtml(__('Read more →')); ?></a>


### PR DESCRIPTION
<!--
Thanks for opening a pull request. A short summary plus the checklist below keeps reviews fast.
-->

## Summary

<!-- What does this PR do? 2-3 bullets is plenty. -->

- Removes the EscapeHtml from the excerpt in the card.phtml template.
- Follows the /** no esacepe */ used for content

## Motivation

<!-- Why is the change needed? Link the related issue: Closes #123. -->

Closes #3 

## How to test

<!-- Step-by-step, or "run phpunit" if purely internal. -->

1. Create a Blog & a Category/Tag/Author and Create the short content with page builder elements
2. Proceed to a list page Blog/Category/Tag/Author
3. Check the displayed Short Content, there should be no pagebuilder source present only the displayed content

## Checklist

- [x] Branch is based on the latest `main`.
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `refactor:`, `test:`, `chore:`, `docs:`).
- [x] `vendor/bin/phpunit --testsuite unit` passes locally.
- [x] `vendor/bin/phpstan analyse --memory-limit=1G` passes locally.
- [ ] `vendor/bin/phpcs --standard=phpcs.xml.dist` passes locally.
- [ ] `vendor/bin/php-cs-fixer fix --dry-run --diff --allow-risky=yes` shows no changes needed.
- [x] New PHP files start with `declare(strict_types=1);`.
- [x] User-facing change has a `CHANGELOG.md` entry under `## [Unreleased]`.
- [x] No raw integer IDs in admin UX (use pickers / linked names. See `CONTRIBUTING.md`).

## Screenshots / GraphQL samples (if UI or API change)

<!-- Drag screenshots here, or paste a sample query + response. -->
