### PR TITLE
fix(api): add docblocks to extensible interfaces for setup:di:compile

### DIFF
--- a/Api/Data/AuthorInterface.php
+++ b/Api/Data/AuthorInterface.php
@@ -19,27 +19,49 @@ interface AuthorInterface extends ExtensibleDataInterface
     public const WEBSITE = 'website';
     public const IS_ACTIVE = 'is_active';
 
+    /** @return int|null */
     public function getAuthorId(): ?int;
+    /** @param int $id @return self */
     public function setAuthorId(int $id): self;
+    /** @return string */
     public function getSlug(): string;
+    /** @param string $slug @return self */
     public function setSlug(string $slug): self;
+    /** @return string */
     public function getName(): string;
+    /** @param string $name @return self */
     public function setName(string $name): self;
+    /** @return string|null */
     public function getBio(): ?string;
+    /** @param string|null $bio @return self */
     public function setBio(?string $bio): self;
+    /** @return string|null */
     public function getAvatar(): ?string;
+    /** @param string|null $path @return self */
     public function setAvatar(?string $path): self;
+    /** @return string|null */
     public function getEmail(): ?string;
+    /** @param string|null $email @return self */
     public function setEmail(?string $email): self;
+    /** @return string|null */
     public function getTwitter(): ?string;
+    /** @param string|null $twitter @return self */
     public function setTwitter(?string $twitter): self;
+    /** @return string|null */
     public function getLinkedin(): ?string;
+    /** @param string|null $linkedin @return self */
     public function setLinkedin(?string $linkedin): self;
+    /** @return string|null */
     public function getWebsite(): ?string;
+    /** @param string|null $website @return self */
     public function setWebsite(?string $website): self;
+    /** @return bool */
     public function getIsActive(): bool;
+    /** @param bool $flag @return self */
     public function setIsActive(bool $flag): self;
 
+    /** @return \MageOS\Blog\Api\Data\AuthorExtensionInterface|null */
     public function getExtensionAttributes(): ?AuthorExtensionInterface;
+    /** @param \MageOS\Blog\Api\Data\AuthorExtensionInterface $extensionAttributes @return self */
     public function setExtensionAttributes(AuthorExtensionInterface $extensionAttributes): self;
 }

--- a/Api/Data/CategoryInterface.php
+++ b/Api/Data/CategoryInterface.php
@@ -51,6 +51,8 @@ interface CategoryInterface extends ExtensibleDataInterface
     /** @param int[] $storeIds */
     public function setStoreIds(array $storeIds): self;
 
+    /** @return \MageOS\Blog\Api\Data\CategoryExtensionInterface|null */
     public function getExtensionAttributes(): ?CategoryExtensionInterface;
+    /** @param \MageOS\Blog\Api\Data\CategoryExtensionInterface $extensionAttributes @return self */
     public function setExtensionAttributes(CategoryExtensionInterface $extensionAttributes): self;
 }

--- a/Api/Data/PostInterface.php
+++ b/Api/Data/PostInterface.php
@@ -95,6 +95,8 @@ interface PostInterface extends ExtensibleDataInterface
     /** @param int[] $ids */
     public function setRelatedProductIds(array $ids): self;
 
+    /** @return \MageOS\Blog\Api\Data\PostExtensionInterface|null */
     public function getExtensionAttributes(): ?PostExtensionInterface;
+    /** @param \MageOS\Blog\Api\Data\PostExtensionInterface $extensionAttributes @return self */
     public function setExtensionAttributes(PostExtensionInterface $extensionAttributes): self;
 }

--- a/Api/Data/TagInterface.php
+++ b/Api/Data/TagInterface.php
@@ -36,6 +36,8 @@ interface TagInterface extends ExtensibleDataInterface
     /** @param int[] $storeIds */
     public function setStoreIds(array $storeIds): self;
 
+    /** @return \MageOS\Blog\Api\Data\TagExtensionInterface|null */
     public function getExtensionAttributes(): ?TagExtensionInterface;
+    /** @param \MageOS\Blog\Api\Data\TagExtensionInterface $extensionAttributes @return self */
     public function setExtensionAttributes(TagExtensionInterface $extensionAttributes): self;
 }


### PR DESCRIPTION
Magento's `\Magento\Framework\Reflection\TypeProcessor::getReturnFromDocBlock()` introspects interface methods during extension-attribute scaffolding and throws "Each method must have a doc block" whenever a reflected method's `getDocBlock()` returns null.

`AuthorInterface` had no docblocks at all, so `bin/magento setup:di:compile` failed on the first method it walked (`getExtensionAttributes()`). `Post/Category/Tag` interfaces had partial docblocks but were still missing them on `get/setExtensionAttributes()`, which TypeProcessor needs because the return type narrows from `ExtensionAttributesInterface` to the generated `<Entity>ExtensionInterface`.

Adds minimal `@return` / `@param` PHPDoc on every affected method so di:compile succeeds without changing any runtime behaviour or signatures.
