### PR TITLE
ci: replace with check-extension

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,25 +1,33 @@
 name: CI
+
 on:
   push:
-    branches: [main]
+    branches:
+      - main
   pull_request:
+    branches:
+      - main
 
 jobs:
-  unit:
-    name: Unit tests
-    runs-on: ubuntu-22.04
-    strategy:
-      matrix:
-        php: ['8.2', '8.3']
+  compute_matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.supported-version.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: shivammathur/setup-php@v2
-        with:
-          php-version: ${{ matrix.php }}
-          coverage: pcov
-      - run: composer install --no-interaction --prefer-dist
-      - run: vendor/bin/phpunit --testsuite unit
+      - uses: actions/checkout@v6
+      - uses: graycoreio/github-actions-magento2/supported-version@v8.5.0 # x-release-please-version
+        id: supported-version
+      - run: echo ${{ steps.supported-version.outputs.matrix }}
+  check-extension:
+    needs: compute_matrix
+    uses: graycoreio/github-actions-magento2/.github/workflows/check-extension.yaml@v8.5.0 # x-release-please-version
+    with:
+      matrix: ${{ needs.compute_matrix.outputs.matrix }}
+    secrets:
+      composer_auth: ${{ secrets.COMPOSER_AUTH }}
 
+  # The jobs below cover checks not performed by check-extension.yaml
+  # (which handles unit tests, integration tests, phpcs, and DI compile).
   static:
     name: PHPStan
     runs-on: ubuntu-22.04
@@ -29,41 +37,6 @@ jobs:
         with: { php-version: '8.3' }
       - run: composer install --no-interaction --prefer-dist
       - run: vendor/bin/phpstan analyse --memory-limit=1G --no-progress
-
-  cs:
-    name: Code style
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@v4
-      - uses: shivammathur/setup-php@v2
-        with: { php-version: '8.3' }
-      - run: composer install --no-interaction --prefer-dist
-      - run: vendor/bin/php-cs-fixer fix --dry-run --diff --allow-risky=yes
-      - run: vendor/bin/phpcs --standard=phpcs.xml.dist
-
-  integration-matrix:
-    name: Compute integration matrix
-    runs-on: ubuntu-22.04
-    outputs:
-      matrix: ${{ steps.supported.outputs.matrix }}
-    steps:
-      - uses: actions/checkout@v4
-      - id: supported
-        uses: graycoreio/github-actions-magento2/supported-version@main
-        with:
-          kind: currently-supported
-          project: magento-open-source
-          include_services: 'true'
-
-  integration:
-    name: Integration tests
-    needs: integration-matrix
-    uses: graycoreio/github-actions-magento2/.github/workflows/integration.yaml@main
-    with:
-      package_name: mageos/module-blog
-      matrix: ${{ needs.integration-matrix.outputs.matrix }}
-    secrets:
-      composer_auth: ${{ secrets.COMPOSER_AUTH }}
 
   infection:
     name: Mutation testing

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,12 +15,12 @@ jobs:
       matrix: ${{ steps.supported-version.outputs.matrix }}
     steps:
       - uses: actions/checkout@v6
-      - uses: graycoreio/github-actions-magento2/supported-version@v8.5.0 # x-release-please-version
+      - uses: graycoreio/github-actions-magento2/supported-version@v8.7.0 # x-release-please-version
         id: supported-version
       - run: echo ${{ steps.supported-version.outputs.matrix }}
   check-extension:
     needs: compute_matrix
-    uses: graycoreio/github-actions-magento2/.github/workflows/check-extension.yaml@v8.5.0 # x-release-please-version
+    uses: graycoreio/github-actions-magento2/.github/workflows/check-extension.yaml@v8.7.0 # x-release-please-version
     with:
       matrix: ${{ needs.compute_matrix.outputs.matrix }}
     secrets:


### PR DESCRIPTION
## Summary

- Replace the bespoke `.github/workflows/ci.yml` with the graycoreio `check-extension` reusable workflow (`@v8.5.0`), driven by a `compute_matrix` job that pulls the currently-supported Magento versions. This covers unit tests, integration tests, phpcs, and DI compile across the supported version matrix.
- Keep the checks `check-extension` does **not** provide as standalone jobs: `static` (PHPStan) and `infection` (PR-only mutation testing).
- Drop the standalone `phpcs` and `php-cs-fixer` steps — phpcs is now handled by the reusable workflow's `coding-standard` action

## Motivation

Replace hand-maintained CI matrix/install logic with the shared, versioned `graycoreio/github-actions-magento2` workflow so supported-version coverage and Magento install steps stay current automatically, while preserving project-specific static analysis and mutation testing.

## How to test

1. Open this PR and confirm the Actions run triggers `compute_matrix`, `check-extension` (matrixed across the resolved Magento versions), `static`, and `infection`.
2. Verify `check-extension` runs unit + integration tests, phpcs, and DI compile and passes.
3. Confirm `static` (PHPStan) and `infection` (mutation testing, PR-only) run and pass.

## Checklist

- [x] Branch is based on the latest `main`.
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `refactor:`, `test:`, `chore:`, `docs:`).
- [ ] `vendor/bin/phpunit --testsuite unit` passes locally.
- [ ] `vendor/bin/phpstan analyse --memory-limit=1G` passes locally.
- [ ] `vendor/bin/phpcs --standard=phpcs.xml.dist` passes locally.
- [x] New PHP files start with `declare(strict_types=1);`. (n/a — no PHP files changed)
- [ ] User-facing change has a `CHANGELOG.md` entry under `## [Unreleased]`. (n/a — CI-only change)
- [x] No raw integer IDs in admin UX (use pickers / linked names. See `CONTRIBUTING.md`). (n/a — no UX change)

## Screenshots / GraphQL samples (if UI or API change)

n/a — CI configuration change only.
