### PR TITLE
fix: integration tests and phpcs error

### DIFF
--- a/Controller/Rss/Index.php
+++ b/Controller/Rss/Index.php
@@ -55,23 +55,23 @@ class Index implements HttpGetActionInterface
         $channel = $xml->createElement('channel');
         $rss->appendChild($channel);
 
-        // phpcs:ignore Magento2.Functions.DiscouragedFunction.DiscouragedWithAlternative -- ENT_XML1 context, not HTML
         $channel->appendChild($xml->createElement(
             'title',
+            // phpcs:ignore Magento2.Functions.DiscouragedFunction.DiscouragedWithAlternative
             htmlspecialchars((string) ($data['title'] ?? ''), ENT_XML1)
         ));
-        // phpcs:ignore Magento2.Functions.DiscouragedFunction.DiscouragedWithAlternative -- ENT_XML1 context, not HTML
         $channel->appendChild($xml->createElement(
             'description',
+            // phpcs:ignore Magento2.Functions.DiscouragedFunction.DiscouragedWithAlternative
             htmlspecialchars((string) ($data['description'] ?? ''), ENT_XML1)
         ));
         $channel->appendChild($xml->createElement('link', (string) ($data['link'] ?? '')));
 
         foreach ((array) ($data['entries'] ?? []) as $entry) {
             $item = $xml->createElement('item');
-            // phpcs:ignore Magento2.Functions.DiscouragedFunction.DiscouragedWithAlternative -- ENT_XML1 context, not HTML
             $item->appendChild($xml->createElement(
                 'title',
+                // phpcs:ignore Magento2.Functions.DiscouragedFunction.DiscouragedWithAlternative
                 htmlspecialchars((string) ($entry['title'] ?? ''), ENT_XML1)
             ));
             $item->appendChild($xml->createElement('link', (string) ($entry['link'] ?? '')));

--- a/Test/Integration/Controller/StorefrontRoutingTest.php
+++ b/Test/Integration/Controller/StorefrontRoutingTest.php
@@ -12,6 +12,7 @@ use MageOS\Blog\Api\Data\PostInterfaceFactory;
 use MageOS\Blog\Api\PostRepositoryInterface;
 use MageOS\Blog\Model\BlogPostStatus;
 use MageOS\Blog\Model\Config;
+use MageOS\Blog\Model\PostRepository;
 
 class StorefrontRoutingTest extends AbstractController
 {
@@ -22,7 +23,8 @@ class StorefrontRoutingTest extends AbstractController
     {
         parent::setUp();
         $objectManager = Bootstrap::getObjectManager();
-        $this->repository = $objectManager->get(PostRepositoryInterface::class);
+        $this->repository = $objectManager->get(PostRepositoryInterface::class)
+            ?? $objectManager->get(PostRepository::class);
         $this->postFactory = $objectManager->get(PostInterfaceFactory::class);
 
         /** @var MutableScopeConfigInterface $scopeConfig */


### PR DESCRIPTION
<!--
Thanks for opening a pull request. A short summary plus the checklist below keeps reviews fast.
-->

## Summary

<!-- What does this PR do? 2-3 bullets is plenty. -->

- fixes remaining errors blocking #6 
- 

## Motivation

<!-- Why is the change needed? Link the related issue: Closes #123. -->

Unblocks #6 

## How to test

<!-- Step-by-step, or "run phpunit" if purely internal. -->

1. 
2. 

## Checklist

- [x] Branch is based on the latest `main`.
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `refactor:`, `test:`, `chore:`, `docs:`).
- [x] `vendor/bin/phpunit --testsuite unit` passes locally.
- [x] `vendor/bin/phpstan analyse --memory-limit=1G` passes locally.
- [x] `vendor/bin/phpcs --standard=phpcs.xml.dist` passes locally.
- [x] `vendor/bin/php-cs-fixer fix --dry-run --diff --allow-risky=yes` shows no changes needed.
- [x] New PHP files start with `declare(strict_types=1);`.
- [x] User-facing change has a `CHANGELOG.md` entry under `## [Unreleased]`.
- [x] No raw integer IDs in admin UX (use pickers / linked names. See `CONTRIBUTING.md`).

## Screenshots / GraphQL samples (if UI or API change)

<!-- Drag screenshots here, or paste a sample query + response. -->
