### PR TITLE
PR: Fix Tests to allow PR #6 to pass & merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,34 +1,25 @@
 name: CI
-
 on:
   push:
-    branches:
-      - main
-      - ci/**
+    branches: [main]
   pull_request:
-    branches:
-      - main
 
 jobs:
-  compute_matrix:
-    runs-on: ubuntu-latest
-    outputs:
-      matrix: ${{ steps.supported-version.outputs.matrix }}
+  unit:
+    name: Unit tests
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        php: ['8.2', '8.3']
     steps:
-      - uses: actions/checkout@v6
-      - uses: graycoreio/github-actions-magento2/supported-version@v8.7.0 # x-release-please-version
-        id: supported-version
-      - run: echo ${{ steps.supported-version.outputs.matrix }}
-  check-extension:
-    needs: compute_matrix
-    uses: graycoreio/github-actions-magento2/.github/workflows/check-extension.yaml@v8.7.0 # x-release-please-version
-    with:
-      matrix: ${{ needs.compute_matrix.outputs.matrix }}
-    secrets:
-      composer_auth: ${{ secrets.COMPOSER_AUTH }}
+      - uses: actions/checkout@v4
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          coverage: pcov
+      - run: composer install --no-interaction --prefer-dist
+      - run: vendor/bin/phpunit --testsuite unit
 
-  # The jobs below cover checks not performed by check-extension.yaml
-  # (which handles unit tests, integration tests, phpcs, and DI compile).
   static:
     name: PHPStan
     runs-on: ubuntu-22.04
@@ -38,6 +29,41 @@ jobs:
         with: { php-version: '8.3' }
       - run: composer install --no-interaction --prefer-dist
       - run: vendor/bin/phpstan analyse --memory-limit=1G --no-progress
+
+  cs:
+    name: Code style
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: shivammathur/setup-php@v2
+        with: { php-version: '8.3' }
+      - run: composer install --no-interaction --prefer-dist
+      - run: vendor/bin/php-cs-fixer fix --dry-run --diff --allow-risky=yes
+      - run: vendor/bin/phpcs --standard=phpcs.xml.dist
+
+  integration-matrix:
+    name: Compute integration matrix
+    runs-on: ubuntu-22.04
+    outputs:
+      matrix: ${{ steps.supported.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: supported
+        uses: graycoreio/github-actions-magento2/supported-version@main
+        with:
+          kind: currently-supported
+          project: magento-open-source
+          include_services: 'true'
+
+  integration:
+    name: Integration tests
+    needs: integration-matrix
+    uses: graycoreio/github-actions-magento2/.github/workflows/integration.yaml@main
+    with:
+      package_name: mageos/module-blog
+      matrix: ${{ needs.integration-matrix.outputs.matrix }}
+    secrets:
+      composer_auth: ${{ secrets.COMPOSER_AUTH }}
 
   infection:
     name: Mutation testing

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,25 +1,34 @@
 name: CI
+
 on:
   push:
-    branches: [main]
+    branches:
+      - main
+      - ci/**
   pull_request:
+    branches:
+      - main
 
 jobs:
-  unit:
-    name: Unit tests
-    runs-on: ubuntu-22.04
-    strategy:
-      matrix:
-        php: ['8.2', '8.3']
+  compute_matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.supported-version.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: shivammathur/setup-php@v2
-        with:
-          php-version: ${{ matrix.php }}
-          coverage: pcov
-      - run: composer install --no-interaction --prefer-dist
-      - run: vendor/bin/phpunit --testsuite unit
+      - uses: actions/checkout@v6
+      - uses: graycoreio/github-actions-magento2/supported-version@v8.7.0 # x-release-please-version
+        id: supported-version
+      - run: echo ${{ steps.supported-version.outputs.matrix }}
+  check-extension:
+    needs: compute_matrix
+    uses: graycoreio/github-actions-magento2/.github/workflows/check-extension.yaml@v8.7.0 # x-release-please-version
+    with:
+      matrix: ${{ needs.compute_matrix.outputs.matrix }}
+    secrets:
+      composer_auth: ${{ secrets.COMPOSER_AUTH }}
 
+  # The jobs below cover checks not performed by check-extension.yaml
+  # (which handles unit tests, integration tests, phpcs, and DI compile).
   static:
     name: PHPStan
     runs-on: ubuntu-22.04
@@ -29,41 +38,6 @@ jobs:
         with: { php-version: '8.3' }
       - run: composer install --no-interaction --prefer-dist
       - run: vendor/bin/phpstan analyse --memory-limit=1G --no-progress
-
-  cs:
-    name: Code style
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@v4
-      - uses: shivammathur/setup-php@v2
-        with: { php-version: '8.3' }
-      - run: composer install --no-interaction --prefer-dist
-      - run: vendor/bin/php-cs-fixer fix --dry-run --diff --allow-risky=yes
-      - run: vendor/bin/phpcs --standard=phpcs.xml.dist
-
-  integration-matrix:
-    name: Compute integration matrix
-    runs-on: ubuntu-22.04
-    outputs:
-      matrix: ${{ steps.supported.outputs.matrix }}
-    steps:
-      - uses: actions/checkout@v4
-      - id: supported
-        uses: graycoreio/github-actions-magento2/supported-version@main
-        with:
-          kind: currently-supported
-          project: magento-open-source
-          include_services: 'true'
-
-  integration:
-    name: Integration tests
-    needs: integration-matrix
-    uses: graycoreio/github-actions-magento2/.github/workflows/integration.yaml@main
-    with:
-      package_name: mageos/module-blog
-      matrix: ${{ needs.integration-matrix.outputs.matrix }}
-    secrets:
-      composer_auth: ${{ secrets.COMPOSER_AUTH }}
 
   infection:
     name: Mutation testing

--- a/Controller/Rss/Index.php
+++ b/Controller/Rss/Index.php
@@ -55,23 +55,23 @@ class Index implements HttpGetActionInterface
         $channel = $xml->createElement('channel');
         $rss->appendChild($channel);
 
-        // phpcs:ignore Magento2.Functions.DiscouragedFunction.DiscouragedWithAlternative -- ENT_XML1 context, not HTML
         $channel->appendChild($xml->createElement(
             'title',
+            // phpcs:ignore Magento2.Functions.DiscouragedFunction.DiscouragedWithAlternative
             htmlspecialchars((string) ($data['title'] ?? ''), ENT_XML1)
         ));
-        // phpcs:ignore Magento2.Functions.DiscouragedFunction.DiscouragedWithAlternative -- ENT_XML1 context, not HTML
         $channel->appendChild($xml->createElement(
             'description',
+            // phpcs:ignore Magento2.Functions.DiscouragedFunction.DiscouragedWithAlternative
             htmlspecialchars((string) ($data['description'] ?? ''), ENT_XML1)
         ));
         $channel->appendChild($xml->createElement('link', (string) ($data['link'] ?? '')));
 
         foreach ((array) ($data['entries'] ?? []) as $entry) {
             $item = $xml->createElement('item');
-            // phpcs:ignore Magento2.Functions.DiscouragedFunction.DiscouragedWithAlternative -- ENT_XML1 context, not HTML
             $item->appendChild($xml->createElement(
                 'title',
+                // phpcs:ignore Magento2.Functions.DiscouragedFunction.DiscouragedWithAlternative
                 htmlspecialchars((string) ($entry['title'] ?? ''), ENT_XML1)
             ));
             $item->appendChild($xml->createElement('link', (string) ($entry['link'] ?? '')));

--- a/Test/Integration/Controller/StorefrontRoutingTest.php
+++ b/Test/Integration/Controller/StorefrontRoutingTest.php
@@ -25,7 +25,7 @@ class StorefrontRoutingTest extends AbstractController
     {
         parent::setUp();
         $this->objectManager = ObjectManager::getInstance();
-        $objectManager = $this->objectManager;//Bootstrap::getObjectManager();
+        $objectManager = $this->objectManager;
         $this->repository = $objectManager->get(PostRepositoryInterface::class);
         $this->postFactory = $objectManager->get(PostInterfaceFactory::class);
 

--- a/Test/Integration/Controller/StorefrontRoutingTest.php
+++ b/Test/Integration/Controller/StorefrontRoutingTest.php
@@ -6,7 +6,7 @@ namespace MageOS\Blog\Test\Integration\Controller;
 
 use Magento\Framework\App\Config\MutableScopeConfigInterface;
 use Magento\Store\Model\ScopeInterface;
-use Magento\TestFramework\Helper\Bootstrap;
+use Magento\TestFramework\ObjectManager as ObjectManager;
 use Magento\TestFramework\TestCase\AbstractController;
 use MageOS\Blog\Api\Data\PostInterfaceFactory;
 use MageOS\Blog\Api\PostRepositoryInterface;
@@ -18,10 +18,14 @@ class StorefrontRoutingTest extends AbstractController
     private PostRepositoryInterface $repository;
     private PostInterfaceFactory $postFactory;
 
+    /** @var ObjectManager */
+    private $objectManager;
+
     protected function setUp(): void
     {
         parent::setUp();
-        $objectManager = Bootstrap::getObjectManager();
+        $this->objectManager = ObjectManager::getInstance();
+        $objectManager = $this->objectManager;//Bootstrap::getObjectManager();
         $this->repository = $objectManager->get(PostRepositoryInterface::class);
         $this->postFactory = $objectManager->get(PostInterfaceFactory::class);
 

--- a/Test/Integration/Controller/StorefrontRoutingTest.php
+++ b/Test/Integration/Controller/StorefrontRoutingTest.php
@@ -12,6 +12,7 @@ use MageOS\Blog\Api\Data\PostInterfaceFactory;
 use MageOS\Blog\Api\PostRepositoryInterface;
 use MageOS\Blog\Model\BlogPostStatus;
 use MageOS\Blog\Model\Config;
+use MageOS\Blog\Model\PostRepository;
 
 class StorefrontRoutingTest extends AbstractController
 {
@@ -22,7 +23,8 @@ class StorefrontRoutingTest extends AbstractController
     {
         parent::setUp();
         $objectManager = Bootstrap::getObjectManager();
-        $this->repository = $objectManager->get(PostRepositoryInterface::class);
+        $this->repository = $objectManager->get(PostRepositoryInterface::class)
+            ?? $objectManager->get(PostRepository::class);
         $this->postFactory = $objectManager->get(PostInterfaceFactory::class);
 
         /** @var MutableScopeConfigInterface $scopeConfig */

--- a/Test/Integration/Controller/StorefrontRoutingTest.php
+++ b/Test/Integration/Controller/StorefrontRoutingTest.php
@@ -6,42 +6,39 @@ namespace MageOS\Blog\Test\Integration\Controller;
 
 use Magento\Framework\App\Config\MutableScopeConfigInterface;
 use Magento\Store\Model\ScopeInterface;
-use Magento\TestFramework\ObjectManager as ObjectManager;
+use Magento\TestFramework\Helper\Bootstrap;
 use Magento\TestFramework\TestCase\AbstractController;
 use MageOS\Blog\Api\Data\PostInterfaceFactory;
 use MageOS\Blog\Api\PostRepositoryInterface;
 use MageOS\Blog\Model\BlogPostStatus;
 use MageOS\Blog\Model\Config;
 
+/**
+ * @magentoAppArea frontend
+ * @magentoDbIsolation enabled
+ * @magentoAppIsolation enabled
+ */
 class StorefrontRoutingTest extends AbstractController
 {
-    private PostRepositoryInterface $repository;
-    private PostInterfaceFactory $postFactory;
-
-    /** @var ObjectManager */
-    private $objectManager;
-
     protected function setUp(): void
     {
         parent::setUp();
-        $this->objectManager = ObjectManager::getInstance();
-        $objectManager = $this->objectManager;
-        $this->repository = $objectManager->get(PostRepositoryInterface::class);
-        $this->postFactory = $objectManager->get(PostInterfaceFactory::class);
 
-        /** @var MutableScopeConfigInterface $scopeConfig */
         $scopeConfig = $this->_objectManager->get(MutableScopeConfigInterface::class);
         $scopeConfig->setValue(Config::XML_PATH_ENABLED, '1', ScopeInterface::SCOPE_STORE);
     }
 
     public function test_post_view_returns_200_for_published_post(): void
     {
-        $post = $this->postFactory->create();
+        $postFactory = Bootstrap::getObjectManager()->get(PostInterfaceFactory::class);
+        $repository = Bootstrap::getObjectManager()->get(PostRepositoryInterface::class);
+
+        $post = $postFactory->create();
         $post->setTitle('Storefront Test')
             ->setUrlKey('storefront-routing-test')
             ->setStatus(BlogPostStatus::Published->value)
             ->setStoreIds([1]);
-        $saved = $this->repository->save($post);
+        $repository->save($post);
 
         $this->dispatch('/blog/storefront-routing-test');
 
@@ -50,7 +47,6 @@ class StorefrontRoutingTest extends AbstractController
 
     public function test_disabled_module_forwards_to_noroute(): void
     {
-        /** @var MutableScopeConfigInterface $scopeConfig */
         $scopeConfig = $this->_objectManager->get(MutableScopeConfigInterface::class);
         $scopeConfig->setValue(Config::XML_PATH_ENABLED, '0', ScopeInterface::SCOPE_STORE);
 
@@ -62,6 +58,7 @@ class StorefrontRoutingTest extends AbstractController
     public function test_unknown_slug_returns_404(): void
     {
         $this->dispatch('/blog/does-not-exist-' . uniqid());
+
         $this->assertEquals(404, $this->getResponse()->getHttpResponseCode());
     }
 }

--- a/Test/Integration/Controller/StorefrontRoutingTest.php
+++ b/Test/Integration/Controller/StorefrontRoutingTest.php
@@ -12,7 +12,6 @@ use MageOS\Blog\Api\Data\PostInterfaceFactory;
 use MageOS\Blog\Api\PostRepositoryInterface;
 use MageOS\Blog\Model\BlogPostStatus;
 use MageOS\Blog\Model\Config;
-use MageOS\Blog\Model\PostRepository;
 
 class StorefrontRoutingTest extends AbstractController
 {
@@ -23,8 +22,7 @@ class StorefrontRoutingTest extends AbstractController
     {
         parent::setUp();
         $objectManager = Bootstrap::getObjectManager();
-        $this->repository = $objectManager->get(PostRepositoryInterface::class)
-            ?? $objectManager->get(PostRepository::class);
+        $this->repository = $objectManager->get(PostRepositoryInterface::class);
         $this->postFactory = $objectManager->get(PostInterfaceFactory::class);
 
         /** @var MutableScopeConfigInterface $scopeConfig */

--- a/Test/Integration/Cron/PublishScheduledPostsTest.php
+++ b/Test/Integration/Cron/PublishScheduledPostsTest.php
@@ -14,6 +14,10 @@ use MageOS\Blog\Model\BlogPostStatus;
 use MageOS\Blog\Model\Config;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @magentoAppArea adminhtml
+ * @magentoDbIsolation enabled
+ */
 final class PublishScheduledPostsTest extends TestCase
 {
     private PublishScheduledPosts $cron;

--- a/Test/Integration/Cron/PublishScheduledPostsTest.php
+++ b/Test/Integration/Cron/PublishScheduledPostsTest.php
@@ -15,56 +15,61 @@ use MageOS\Blog\Model\Config;
 use PHPUnit\Framework\TestCase;
 
 /**
- * @magentoAppArea adminhtml
+ * @magentoAppArea crontab
  * @magentoDbIsolation enabled
  */
 final class PublishScheduledPostsTest extends TestCase
 {
-    private PublishScheduledPosts $cron;
-    private PostRepositoryInterface $repository;
-    private PostInterfaceFactory $postFactory;
-
     protected function setUp(): void
     {
-        $om = Bootstrap::getObjectManager();
-        $this->cron = $om->get(PublishScheduledPosts::class);
-        $this->repository = $om->get(PostRepositoryInterface::class);
-        $this->postFactory = $om->get(PostInterfaceFactory::class);
-
-        /** @var MutableScopeConfigInterface $scopeConfig */
-        $scopeConfig = $om->get(MutableScopeConfigInterface::class);
+        $scopeConfig = Bootstrap::getObjectManager()->get(MutableScopeConfigInterface::class);
         $scopeConfig->setValue(Config::XML_PATH_ENABLED, '1', ScopeInterface::SCOPE_STORE);
     }
 
     public function test_cron_publishes_posts_with_past_publish_date(): void
     {
-        $post = $this->postFactory->create();
+        $post = $this->postFactory()->create();
         $post->setTitle('Scheduled Post')
             ->setUrlKey('cron-scheduled-' . uniqid())
             ->setStatus(BlogPostStatus::Scheduled->value)
             ->setPublishDate(gmdate('Y-m-d H:i:s', time() - 600))
             ->setStoreIds([1]);
-        $saved = $this->repository->save($post);
+        $saved = $this->repository()->save($post);
 
-        $this->cron->execute();
+        $this->cron()->execute();
 
-        $reloaded = $this->repository->getById((int) $saved->getPostId());
+        $reloaded = $this->repository()->getById((int) $saved->getPostId());
         self::assertSame(BlogPostStatus::Published->value, $reloaded->getStatus());
     }
 
     public function test_cron_leaves_future_scheduled_posts_alone(): void
     {
-        $post = $this->postFactory->create();
+        $post = $this->postFactory()->create();
         $post->setTitle('Future Post')
             ->setUrlKey('cron-future-' . uniqid())
             ->setStatus(BlogPostStatus::Scheduled->value)
             ->setPublishDate(gmdate('Y-m-d H:i:s', time() + 3600))
             ->setStoreIds([1]);
-        $saved = $this->repository->save($post);
+        $saved = $this->repository()->save($post);
 
-        $this->cron->execute();
+        $this->cron()->execute();
 
-        $reloaded = $this->repository->getById((int) $saved->getPostId());
+        $reloaded = $this->repository()->getById((int) $saved->getPostId());
         self::assertSame(BlogPostStatus::Scheduled->value, $reloaded->getStatus());
+    }
+
+    private function cron(): PublishScheduledPosts
+    {
+        return Bootstrap::getObjectManager()->get(PublishScheduledPosts::class);
+    }
+
+    private function repository(): PostRepositoryInterface
+    {
+        return Bootstrap::getObjectManager()->get(PostRepositoryInterface::class);
+    }
+
+    private function postFactory(): PostInterfaceFactory
+    {
+        return Bootstrap::getObjectManager()->get(PostInterfaceFactory::class);
     }
 }

--- a/Test/Integration/Model/AuthorRepositoryTest.php
+++ b/Test/Integration/Model/AuthorRepositoryTest.php
@@ -13,6 +13,10 @@ use MageOS\Blog\Api\Data\AuthorInterface;
 use MageOS\Blog\Api\Data\AuthorInterfaceFactory;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @magentoAppArea adminhtml
+ * @magentoDbIsolation enabled
+ */
 final class AuthorRepositoryTest extends TestCase
 {
     private AuthorRepositoryInterface $repository;

--- a/Test/Integration/Model/AuthorRepositoryTest.php
+++ b/Test/Integration/Model/AuthorRepositoryTest.php
@@ -19,23 +19,9 @@ use PHPUnit\Framework\TestCase;
  */
 final class AuthorRepositoryTest extends TestCase
 {
-    private AuthorRepositoryInterface $repository;
-    private AuthorInterfaceFactory $authorFactory;
-    private SearchCriteriaBuilder $searchCriteriaBuilder;
-    private ResourceConnection $resource;
-
-    protected function setUp(): void
-    {
-        $objectManager = Bootstrap::getObjectManager();
-        $this->repository = $objectManager->get(AuthorRepositoryInterface::class);
-        $this->authorFactory = $objectManager->get(AuthorInterfaceFactory::class);
-        $this->searchCriteriaBuilder = $objectManager->get(SearchCriteriaBuilder::class);
-        $this->resource = $objectManager->get(ResourceConnection::class);
-    }
-
     public function test_save_and_load_roundtrip(): void
     {
-        $author = $this->authorFactory->create();
+        $author = $this->authorFactory()->create();
         $author->setName('Jane Doe')
             ->setSlug('jane-doe')
             ->setBio('Writer and editor')
@@ -46,10 +32,10 @@ final class AuthorRepositoryTest extends TestCase
             ->setWebsite('https://janedoe.example.com')
             ->setIsActive(true);
 
-        $saved = $this->repository->save($author);
+        $saved = $this->repository()->save($author);
         self::assertNotNull($saved->getAuthorId());
 
-        $loaded = $this->repository->getById((int) $saved->getAuthorId());
+        $loaded = $this->repository()->getById((int) $saved->getAuthorId());
         self::assertSame('Jane Doe', $loaded->getName());
         self::assertSame('jane-doe', $loaded->getSlug());
         self::assertSame('Writer and editor', $loaded->getBio());
@@ -63,33 +49,33 @@ final class AuthorRepositoryTest extends TestCase
 
     public function test_get_by_slug_returns_author(): void
     {
-        $author = $this->authorFactory->create();
+        $author = $this->authorFactory()->create();
         $author->setName('John Smith')->setSlug('john-smith');
-        $this->repository->save($author);
+        $this->repository()->save($author);
 
-        $found = $this->repository->getBySlug('john-smith');
+        $found = $this->repository()->getBySlug('john-smith');
         self::assertSame('John Smith', $found->getName());
     }
 
     public function test_get_by_slug_throws_on_missing(): void
     {
         $this->expectException(NoSuchEntityException::class);
-        $this->repository->getBySlug('definitely-not-a-slug');
+        $this->repository()->getBySlug('definitely-not-a-slug');
     }
 
     public function test_delete_removes_row(): void
     {
-        $author = $this->authorFactory->create();
+        $author = $this->authorFactory()->create();
         $author->setName('Gone')->setSlug('gone-author');
-        $saved = $this->repository->save($author);
+        $saved = $this->repository()->save($author);
         $authorId = (int) $saved->getAuthorId();
 
-        self::assertTrue($this->repository->deleteById($authorId));
+        self::assertTrue($this->repository()->deleteById($authorId));
 
-        $connection = $this->resource->getConnection();
+        $connection = $this->resource()->getConnection();
         $count = $connection->fetchOne(
             $connection->select()
-                ->from($this->resource->getTableName('mageos_blog_author'), ['COUNT(*)'])
+                ->from($this->resource()->getTableName('mageos_blog_author'), ['COUNT(*)'])
                 ->where('author_id = ?', $authorId)
         );
         self::assertSame(0, (int) $count);
@@ -98,22 +84,42 @@ final class AuthorRepositoryTest extends TestCase
     public function test_get_list_filters_by_slug(): void
     {
         foreach (['alpha', 'beta', 'gamma'] as $slug) {
-            $author = $this->authorFactory->create();
+            $author = $this->authorFactory()->create();
             $author->setName(ucfirst($slug))->setSlug('author-list-' . $slug);
-            $this->repository->save($author);
+            $this->repository()->save($author);
         }
 
-        $criteria = $this->searchCriteriaBuilder
+        $criteria = $this->searchCriteriaBuilder()
             ->addFilter(AuthorInterface::SLUG, 'author-list-%', 'like')
             ->create();
 
-        $results = $this->repository->getList($criteria);
+        $results = $this->repository()->getList($criteria);
         self::assertGreaterThanOrEqual(3, $results->getTotalCount());
     }
 
     public function test_get_by_id_throws_on_missing(): void
     {
         $this->expectException(NoSuchEntityException::class);
-        $this->repository->getById(9999999);
+        $this->repository()->getById(9999999);
+    }
+
+    private function repository(): AuthorRepositoryInterface
+    {
+        return Bootstrap::getObjectManager()->get(AuthorRepositoryInterface::class);
+    }
+
+    private function authorFactory(): AuthorInterfaceFactory
+    {
+        return Bootstrap::getObjectManager()->get(AuthorInterfaceFactory::class);
+    }
+
+    private function searchCriteriaBuilder(): SearchCriteriaBuilder
+    {
+        return Bootstrap::getObjectManager()->get(SearchCriteriaBuilder::class);
+    }
+
+    private function resource(): ResourceConnection
+    {
+        return Bootstrap::getObjectManager()->get(ResourceConnection::class);
     }
 }

--- a/Test/Integration/Model/CategoryRepositoryTest.php
+++ b/Test/Integration/Model/CategoryRepositoryTest.php
@@ -13,6 +13,10 @@ use MageOS\Blog\Api\Data\CategoryInterface;
 use MageOS\Blog\Api\Data\CategoryInterfaceFactory;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @magentoAppArea adminhtml
+ * @magentoDbIsolation enabled
+ */
 final class CategoryRepositoryTest extends TestCase
 {
     private CategoryRepositoryInterface $repository;

--- a/Test/Integration/Model/CategoryRepositoryTest.php
+++ b/Test/Integration/Model/CategoryRepositoryTest.php
@@ -19,31 +19,17 @@ use PHPUnit\Framework\TestCase;
  */
 final class CategoryRepositoryTest extends TestCase
 {
-    private CategoryRepositoryInterface $repository;
-    private CategoryInterfaceFactory $categoryFactory;
-    private SearchCriteriaBuilder $searchCriteriaBuilder;
-    private ResourceConnection $resource;
-
-    protected function setUp(): void
-    {
-        $objectManager = Bootstrap::getObjectManager();
-        $this->repository = $objectManager->get(CategoryRepositoryInterface::class);
-        $this->categoryFactory = $objectManager->get(CategoryInterfaceFactory::class);
-        $this->searchCriteriaBuilder = $objectManager->get(SearchCriteriaBuilder::class);
-        $this->resource = $objectManager->get(ResourceConnection::class);
-    }
-
     public function test_save_and_load_roundtrip(): void
     {
-        $category = $this->categoryFactory->create();
+        $category = $this->categoryFactory()->create();
         $category->setTitle('News')
             ->setUrlKey('news')
             ->setDescription('Latest news');
 
-        $saved = $this->repository->save($category);
+        $saved = $this->repository()->save($category);
         self::assertNotNull($saved->getCategoryId());
 
-        $loaded = $this->repository->getById((int) $saved->getCategoryId());
+        $loaded = $this->repository()->getById((int) $saved->getCategoryId());
         self::assertSame('News', $loaded->getTitle());
         self::assertSame('news', $loaded->getUrlKey());
         self::assertSame('Latest news', $loaded->getDescription());
@@ -51,59 +37,59 @@ final class CategoryRepositoryTest extends TestCase
 
     public function test_save_persists_store_links(): void
     {
-        $category = $this->categoryFactory->create();
+        $category = $this->categoryFactory()->create();
         $category->setTitle('Scoped Category')
             ->setUrlKey('scoped-category')
             ->setStoreIds([1]);
 
-        $saved = $this->repository->save($category);
-        $loaded = $this->repository->getById((int) $saved->getCategoryId());
+        $saved = $this->repository()->save($category);
+        $loaded = $this->repository()->getById((int) $saved->getCategoryId());
 
         self::assertSame([1], $loaded->getStoreIds());
     }
 
     public function test_get_by_url_key_respects_store_scope(): void
     {
-        $category = $this->categoryFactory->create();
+        $category = $this->categoryFactory()->create();
         $category->setTitle('Store 1 Category')
             ->setUrlKey('store-1-category')
             ->setStoreIds([1]);
-        $this->repository->save($category);
+        $this->repository()->save($category);
 
-        $found = $this->repository->getByUrlKey('store-1-category', 1);
+        $found = $this->repository()->getByUrlKey('store-1-category', 1);
         self::assertSame('Store 1 Category', $found->getTitle());
 
         $this->expectException(NoSuchEntityException::class);
-        $this->repository->getByUrlKey('store-1-category', 2);
+        $this->repository()->getByUrlKey('store-1-category', 2);
     }
 
     public function test_get_by_url_key_finds_all_stores_category(): void
     {
-        $category = $this->categoryFactory->create();
+        $category = $this->categoryFactory()->create();
         $category->setTitle('All Stores Category')
             ->setUrlKey('all-stores-category')
             ->setStoreIds([0]);
-        $this->repository->save($category);
+        $this->repository()->save($category);
 
-        $found = $this->repository->getByUrlKey('all-stores-category', 99);
+        $found = $this->repository()->getByUrlKey('all-stores-category', 99);
         self::assertSame('All Stores Category', $found->getTitle());
     }
 
     public function test_delete_removes_pivot_rows(): void
     {
-        $category = $this->categoryFactory->create();
+        $category = $this->categoryFactory()->create();
         $category->setTitle('To Delete')
             ->setUrlKey('to-delete-category')
             ->setStoreIds([1]);
-        $saved = $this->repository->save($category);
+        $saved = $this->repository()->save($category);
         $categoryId = (int) $saved->getCategoryId();
 
-        self::assertTrue($this->repository->deleteById($categoryId));
+        self::assertTrue($this->repository()->deleteById($categoryId));
 
-        $connection = $this->resource->getConnection();
+        $connection = $this->resource()->getConnection();
         $storeCount = $connection->fetchOne(
             $connection->select()
-                ->from($this->resource->getTableName('mageos_blog_category_store'), ['COUNT(*)'])
+                ->from($this->resource()->getTableName('mageos_blog_category_store'), ['COUNT(*)'])
                 ->where('category_id = ?', $categoryId)
         );
         self::assertSame(0, (int) $storeCount);
@@ -112,22 +98,42 @@ final class CategoryRepositoryTest extends TestCase
     public function test_get_list_filters_by_url_key(): void
     {
         foreach (['alpha', 'beta', 'gamma'] as $slug) {
-            $category = $this->categoryFactory->create();
+            $category = $this->categoryFactory()->create();
             $category->setTitle(ucfirst($slug))->setUrlKey('cat-list-' . $slug);
-            $this->repository->save($category);
+            $this->repository()->save($category);
         }
 
-        $criteria = $this->searchCriteriaBuilder
+        $criteria = $this->searchCriteriaBuilder()
             ->addFilter(CategoryInterface::URL_KEY, 'cat-list-%', 'like')
             ->create();
 
-        $results = $this->repository->getList($criteria);
+        $results = $this->repository()->getList($criteria);
         self::assertGreaterThanOrEqual(3, $results->getTotalCount());
     }
 
     public function test_get_by_id_throws_on_missing(): void
     {
         $this->expectException(NoSuchEntityException::class);
-        $this->repository->getById(9999999);
+        $this->repository()->getById(9999999);
+    }
+
+    private function repository(): CategoryRepositoryInterface
+    {
+        return Bootstrap::getObjectManager()->get(CategoryRepositoryInterface::class);
+    }
+
+    private function categoryFactory(): CategoryInterfaceFactory
+    {
+        return Bootstrap::getObjectManager()->get(CategoryInterfaceFactory::class);
+    }
+
+    private function searchCriteriaBuilder(): SearchCriteriaBuilder
+    {
+        return Bootstrap::getObjectManager()->get(SearchCriteriaBuilder::class);
+    }
+
+    private function resource(): ResourceConnection
+    {
+        return Bootstrap::getObjectManager()->get(ResourceConnection::class);
     }
 }

--- a/Test/Integration/Model/PostManagementTest.php
+++ b/Test/Integration/Model/PostManagementTest.php
@@ -11,6 +11,10 @@ use MageOS\Blog\Api\PostRepositoryInterface;
 use MageOS\Blog\Model\BlogPostStatus;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @magentoAppArea adminhtml
+ * @magentoDbIsolation enabled
+ */
 final class PostManagementTest extends TestCase
 {
     private PostManagementInterface $management;

--- a/Test/Integration/Model/PostManagementTest.php
+++ b/Test/Integration/Model/PostManagementTest.php
@@ -17,47 +17,50 @@ use PHPUnit\Framework\TestCase;
  */
 final class PostManagementTest extends TestCase
 {
-    private PostManagementInterface $management;
-    private PostRepositoryInterface $repository;
-    private PostInterfaceFactory $postFactory;
-
-    protected function setUp(): void
-    {
-        $om = Bootstrap::getObjectManager();
-        $this->management = $om->get(PostManagementInterface::class);
-        $this->repository = $om->get(PostRepositoryInterface::class);
-        $this->postFactory = $om->get(PostInterfaceFactory::class);
-    }
-
     public function test_publish_flips_status_to_published(): void
     {
-        $post = $this->postFactory->create();
+        $post = $this->postFactory()->create();
         $post->setTitle('Draft')
             ->setUrlKey('pm-draft-' . uniqid())
             ->setStatus(BlogPostStatus::Draft->value)
             ->setStoreIds([1]);
-        $saved = $this->repository->save($post);
+        $saved = $this->repository()->save($post);
 
-        $this->management->publish((int) $saved->getPostId());
+        $this->management()->publish((int) $saved->getPostId());
 
-        $reloaded = $this->repository->getById((int) $saved->getPostId());
+        $reloaded = $this->repository()->getById((int) $saved->getPostId());
         self::assertSame(BlogPostStatus::Published->value, $reloaded->getStatus());
     }
 
     public function test_increment_views_updates_counter_atomically(): void
     {
-        $post = $this->postFactory->create();
+        $post = $this->postFactory()->create();
         $post->setTitle('Counter')
             ->setUrlKey('pm-counter-' . uniqid())
             ->setStoreIds([1]);
-        $saved = $this->repository->save($post);
+        $saved = $this->repository()->save($post);
         $postId = (int) $saved->getPostId();
 
-        $this->management->incrementViews($postId);
-        $this->management->incrementViews($postId);
-        $this->management->incrementViews($postId);
+        $this->management()->incrementViews($postId);
+        $this->management()->incrementViews($postId);
+        $this->management()->incrementViews($postId);
 
-        $reloaded = $this->repository->getById($postId);
+        $reloaded = $this->repository()->getById($postId);
         self::assertSame(3, $reloaded->getViewsCount());
+    }
+
+    private function management(): PostManagementInterface
+    {
+        return Bootstrap::getObjectManager()->get(PostManagementInterface::class);
+    }
+
+    private function repository(): PostRepositoryInterface
+    {
+        return Bootstrap::getObjectManager()->get(PostRepositoryInterface::class);
+    }
+
+    private function postFactory(): PostInterfaceFactory
+    {
+        return Bootstrap::getObjectManager()->get(PostInterfaceFactory::class);
     }
 }

--- a/Test/Integration/Model/PostRepositoryTest.php
+++ b/Test/Integration/Model/PostRepositoryTest.php
@@ -13,6 +13,10 @@ use MageOS\Blog\Api\Data\PostInterfaceFactory;
 use MageOS\Blog\Api\PostRepositoryInterface;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @magentoAppArea adminhtml
+ * @magentoDbIsolation enabled
+ */
 final class PostRepositoryTest extends TestCase
 {
     private PostRepositoryInterface $repository;

--- a/Test/Integration/Model/PostRepositoryTest.php
+++ b/Test/Integration/Model/PostRepositoryTest.php
@@ -19,31 +19,17 @@ use PHPUnit\Framework\TestCase;
  */
 final class PostRepositoryTest extends TestCase
 {
-    private PostRepositoryInterface $repository;
-    private PostInterfaceFactory $postFactory;
-    private SearchCriteriaBuilder $searchCriteriaBuilder;
-    private ResourceConnection $resource;
-
-    protected function setUp(): void
-    {
-        $objectManager = Bootstrap::getObjectManager();
-        $this->repository = $objectManager->get(PostRepositoryInterface::class);
-        $this->postFactory = $objectManager->get(PostInterfaceFactory::class);
-        $this->searchCriteriaBuilder = $objectManager->get(SearchCriteriaBuilder::class);
-        $this->resource = $objectManager->get(ResourceConnection::class);
-    }
-
     public function test_save_and_load_roundtrip(): void
     {
-        $post = $this->postFactory->create();
+        $post = $this->postFactory()->create();
         $post->setTitle('Hello World')
             ->setUrlKey('hello-world')
             ->setContent('<p>Body</p>');
 
-        $saved = $this->repository->save($post);
+        $saved = $this->repository()->save($post);
         self::assertNotNull($saved->getPostId());
 
-        $loaded = $this->repository->getById((int) $saved->getPostId());
+        $loaded = $this->repository()->getById((int) $saved->getPostId());
         self::assertSame('Hello World', $loaded->getTitle());
         self::assertSame('hello-world', $loaded->getUrlKey());
         self::assertSame('<p>Body</p>', $loaded->getContent());
@@ -51,38 +37,38 @@ final class PostRepositoryTest extends TestCase
 
     public function test_save_persists_store_links(): void
     {
-        $post = $this->postFactory->create();
+        $post = $this->postFactory()->create();
         $post->setTitle('Scoped')->setUrlKey('scoped')->setStoreIds([1]);
 
-        $saved = $this->repository->save($post);
-        $loaded = $this->repository->getById((int) $saved->getPostId());
+        $saved = $this->repository()->save($post);
+        $loaded = $this->repository()->getById((int) $saved->getPostId());
 
         self::assertSame([1], $loaded->getStoreIds());
     }
 
     public function test_save_persists_category_and_tag_links(): void
     {
-        $connection = $this->resource->getConnection();
+        $connection = $this->resource()->getConnection();
         $connection->insert(
-            $this->resource->getTableName('mageos_blog_category'),
+            $this->resource()->getTableName('mageos_blog_category'),
             ['url_key' => 'cat-a', 'title' => 'Cat A']
         );
         $categoryId = (int) $connection->lastInsertId();
 
         $connection->insert(
-            $this->resource->getTableName('mageos_blog_tag'),
+            $this->resource()->getTableName('mageos_blog_tag'),
             ['url_key' => 'tag-a', 'title' => 'Tag A']
         );
         $tagId = (int) $connection->lastInsertId();
 
-        $post = $this->postFactory->create();
+        $post = $this->postFactory()->create();
         $post->setTitle('Taxonomized')
             ->setUrlKey('taxonomized')
             ->setCategoryIds([$categoryId])
             ->setTagIds([$tagId]);
 
-        $saved = $this->repository->save($post);
-        $loaded = $this->repository->getById((int) $saved->getPostId());
+        $saved = $this->repository()->save($post);
+        $loaded = $this->repository()->getById((int) $saved->getPostId());
 
         self::assertSame([$categoryId], $loaded->getCategoryIds());
         self::assertSame([$tagId], $loaded->getTagIds());
@@ -90,40 +76,40 @@ final class PostRepositoryTest extends TestCase
 
     public function test_get_by_url_key_respects_store_scope(): void
     {
-        $post = $this->postFactory->create();
+        $post = $this->postFactory()->create();
         $post->setTitle('Only Store 1')->setUrlKey('only-store-1')->setStoreIds([1]);
-        $this->repository->save($post);
+        $this->repository()->save($post);
 
-        $found = $this->repository->getByUrlKey('only-store-1', 1);
+        $found = $this->repository()->getByUrlKey('only-store-1', 1);
         self::assertSame('Only Store 1', $found->getTitle());
 
         $this->expectException(NoSuchEntityException::class);
-        $this->repository->getByUrlKey('only-store-1', 2);
+        $this->repository()->getByUrlKey('only-store-1', 2);
     }
 
     public function test_get_by_url_key_finds_all_stores_post(): void
     {
-        $post = $this->postFactory->create();
+        $post = $this->postFactory()->create();
         $post->setTitle('All Stores')->setUrlKey('all-stores')->setStoreIds([0]);
-        $this->repository->save($post);
+        $this->repository()->save($post);
 
-        $found = $this->repository->getByUrlKey('all-stores', 99);
+        $found = $this->repository()->getByUrlKey('all-stores', 99);
         self::assertSame('All Stores', $found->getTitle());
     }
 
     public function test_delete_removes_pivot_rows(): void
     {
-        $post = $this->postFactory->create();
+        $post = $this->postFactory()->create();
         $post->setTitle('To Delete')->setUrlKey('to-delete')->setStoreIds([1]);
-        $saved = $this->repository->save($post);
+        $saved = $this->repository()->save($post);
         $postId = (int) $saved->getPostId();
 
-        self::assertTrue($this->repository->deleteById($postId));
+        self::assertTrue($this->repository()->deleteById($postId));
 
-        $connection = $this->resource->getConnection();
+        $connection = $this->resource()->getConnection();
         $storeCount = $connection->fetchOne(
             $connection->select()
-                ->from($this->resource->getTableName('mageos_blog_post_store'), ['COUNT(*)'])
+                ->from($this->resource()->getTableName('mageos_blog_post_store'), ['COUNT(*)'])
                 ->where('post_id = ?', $postId)
         );
         self::assertSame(0, (int) $storeCount);
@@ -132,22 +118,42 @@ final class PostRepositoryTest extends TestCase
     public function test_get_list_filters_by_url_key(): void
     {
         foreach (['alpha', 'beta', 'gamma'] as $slug) {
-            $post = $this->postFactory->create();
+            $post = $this->postFactory()->create();
             $post->setTitle(ucfirst($slug))->setUrlKey('list-' . $slug);
-            $this->repository->save($post);
+            $this->repository()->save($post);
         }
 
-        $criteria = $this->searchCriteriaBuilder
+        $criteria = $this->searchCriteriaBuilder()
             ->addFilter(PostInterface::URL_KEY, 'list-%', 'like')
             ->create();
 
-        $results = $this->repository->getList($criteria);
+        $results = $this->repository()->getList($criteria);
         self::assertGreaterThanOrEqual(3, $results->getTotalCount());
     }
 
     public function test_get_by_id_throws_on_missing(): void
     {
         $this->expectException(NoSuchEntityException::class);
-        $this->repository->getById(9999999);
+        $this->repository()->getById(9999999);
+    }
+
+    private function repository(): PostRepositoryInterface
+    {
+        return Bootstrap::getObjectManager()->get(PostRepositoryInterface::class);
+    }
+
+    private function postFactory(): PostInterfaceFactory
+    {
+        return Bootstrap::getObjectManager()->get(PostInterfaceFactory::class);
+    }
+
+    private function searchCriteriaBuilder(): SearchCriteriaBuilder
+    {
+        return Bootstrap::getObjectManager()->get(SearchCriteriaBuilder::class);
+    }
+
+    private function resource(): ResourceConnection
+    {
+        return Bootstrap::getObjectManager()->get(ResourceConnection::class);
     }
 }

--- a/Test/Integration/Model/ReservedSlugEnforcementTest.php
+++ b/Test/Integration/Model/ReservedSlugEnforcementTest.php
@@ -10,6 +10,10 @@ use MageOS\Blog\Api\Data\PostInterfaceFactory;
 use MageOS\Blog\Api\PostRepositoryInterface;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @magentoAppArea adminhtml
+ * @magentoDbIsolation enabled
+ */
 final class ReservedSlugEnforcementTest extends TestCase
 {
     private PostRepositoryInterface $repository;

--- a/Test/Integration/Model/ReservedSlugEnforcementTest.php
+++ b/Test/Integration/Model/ReservedSlugEnforcementTest.php
@@ -16,35 +16,35 @@ use PHPUnit\Framework\TestCase;
  */
 final class ReservedSlugEnforcementTest extends TestCase
 {
-    private PostRepositoryInterface $repository;
-    private PostInterfaceFactory $postFactory;
-
-    protected function setUp(): void
-    {
-        $om = Bootstrap::getObjectManager();
-        $this->repository = $om->get(PostRepositoryInterface::class);
-        $this->postFactory = $om->get(PostInterfaceFactory::class);
-    }
-
     public function test_save_rejects_reserved_url_key(): void
     {
-        $post = $this->postFactory->create();
+        $post = $this->postFactory()->create();
         $post->setTitle('Category Conflict')
             ->setUrlKey('category')  // reserved
             ->setStoreIds([1]);
 
         $this->expectException(LocalizedException::class);
-        $this->repository->save($post);
+        $this->repository()->save($post);
     }
 
     public function test_save_accepts_non_reserved_url_key(): void
     {
-        $post = $this->postFactory->create();
+        $post = $this->postFactory()->create();
         $post->setTitle('OK')
             ->setUrlKey('reserved-test-' . uniqid())
             ->setStoreIds([1]);
 
-        $saved = $this->repository->save($post);
+        $saved = $this->repository()->save($post);
         self::assertNotNull($saved->getPostId());
+    }
+
+    private function repository(): PostRepositoryInterface
+    {
+        return Bootstrap::getObjectManager()->get(PostRepositoryInterface::class);
+    }
+
+    private function postFactory(): PostInterfaceFactory
+    {
+        return Bootstrap::getObjectManager()->get(PostInterfaceFactory::class);
     }
 }

--- a/Test/Integration/Model/TagRepositoryTest.php
+++ b/Test/Integration/Model/TagRepositoryTest.php
@@ -13,6 +13,10 @@ use MageOS\Blog\Api\Data\TagInterfaceFactory;
 use MageOS\Blog\Api\TagRepositoryInterface;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @magentoAppArea adminhtml
+ * @magentoDbIsolation enabled
+ */
 final class TagRepositoryTest extends TestCase
 {
     private TagRepositoryInterface $repository;

--- a/Test/Integration/Model/TagRepositoryTest.php
+++ b/Test/Integration/Model/TagRepositoryTest.php
@@ -19,31 +19,17 @@ use PHPUnit\Framework\TestCase;
  */
 final class TagRepositoryTest extends TestCase
 {
-    private TagRepositoryInterface $repository;
-    private TagInterfaceFactory $tagFactory;
-    private SearchCriteriaBuilder $searchCriteriaBuilder;
-    private ResourceConnection $resource;
-
-    protected function setUp(): void
-    {
-        $objectManager = Bootstrap::getObjectManager();
-        $this->repository = $objectManager->get(TagRepositoryInterface::class);
-        $this->tagFactory = $objectManager->get(TagInterfaceFactory::class);
-        $this->searchCriteriaBuilder = $objectManager->get(SearchCriteriaBuilder::class);
-        $this->resource = $objectManager->get(ResourceConnection::class);
-    }
-
     public function test_save_and_load_roundtrip(): void
     {
-        $tag = $this->tagFactory->create();
+        $tag = $this->tagFactory()->create();
         $tag->setTitle('Magento')
             ->setUrlKey('magento-tag')
             ->setDescription('Magento related');
 
-        $saved = $this->repository->save($tag);
+        $saved = $this->repository()->save($tag);
         self::assertNotNull($saved->getTagId());
 
-        $loaded = $this->repository->getById((int) $saved->getTagId());
+        $loaded = $this->repository()->getById((int) $saved->getTagId());
         self::assertSame('Magento', $loaded->getTitle());
         self::assertSame('magento-tag', $loaded->getUrlKey());
         self::assertSame('Magento related', $loaded->getDescription());
@@ -51,59 +37,59 @@ final class TagRepositoryTest extends TestCase
 
     public function test_save_persists_store_links(): void
     {
-        $tag = $this->tagFactory->create();
+        $tag = $this->tagFactory()->create();
         $tag->setTitle('Scoped Tag')
             ->setUrlKey('scoped-tag')
             ->setStoreIds([1]);
 
-        $saved = $this->repository->save($tag);
-        $loaded = $this->repository->getById((int) $saved->getTagId());
+        $saved = $this->repository()->save($tag);
+        $loaded = $this->repository()->getById((int) $saved->getTagId());
 
         self::assertSame([1], $loaded->getStoreIds());
     }
 
     public function test_get_by_url_key_respects_store_scope(): void
     {
-        $tag = $this->tagFactory->create();
+        $tag = $this->tagFactory()->create();
         $tag->setTitle('Store 1 Tag')
             ->setUrlKey('store-1-tag')
             ->setStoreIds([1]);
-        $this->repository->save($tag);
+        $this->repository()->save($tag);
 
-        $found = $this->repository->getByUrlKey('store-1-tag', 1);
+        $found = $this->repository()->getByUrlKey('store-1-tag', 1);
         self::assertSame('Store 1 Tag', $found->getTitle());
 
         $this->expectException(NoSuchEntityException::class);
-        $this->repository->getByUrlKey('store-1-tag', 2);
+        $this->repository()->getByUrlKey('store-1-tag', 2);
     }
 
     public function test_get_by_url_key_finds_all_stores_tag(): void
     {
-        $tag = $this->tagFactory->create();
+        $tag = $this->tagFactory()->create();
         $tag->setTitle('All Stores Tag')
             ->setUrlKey('all-stores-tag')
             ->setStoreIds([0]);
-        $this->repository->save($tag);
+        $this->repository()->save($tag);
 
-        $found = $this->repository->getByUrlKey('all-stores-tag', 99);
+        $found = $this->repository()->getByUrlKey('all-stores-tag', 99);
         self::assertSame('All Stores Tag', $found->getTitle());
     }
 
     public function test_delete_removes_pivot_rows(): void
     {
-        $tag = $this->tagFactory->create();
+        $tag = $this->tagFactory()->create();
         $tag->setTitle('To Delete')
             ->setUrlKey('to-delete-tag')
             ->setStoreIds([1]);
-        $saved = $this->repository->save($tag);
+        $saved = $this->repository()->save($tag);
         $tagId = (int) $saved->getTagId();
 
-        self::assertTrue($this->repository->deleteById($tagId));
+        self::assertTrue($this->repository()->deleteById($tagId));
 
-        $connection = $this->resource->getConnection();
+        $connection = $this->resource()->getConnection();
         $storeCount = $connection->fetchOne(
             $connection->select()
-                ->from($this->resource->getTableName('mageos_blog_tag_store'), ['COUNT(*)'])
+                ->from($this->resource()->getTableName('mageos_blog_tag_store'), ['COUNT(*)'])
                 ->where('tag_id = ?', $tagId)
         );
         self::assertSame(0, (int) $storeCount);
@@ -112,22 +98,42 @@ final class TagRepositoryTest extends TestCase
     public function test_get_list_filters_by_url_key(): void
     {
         foreach (['alpha', 'beta', 'gamma'] as $slug) {
-            $tag = $this->tagFactory->create();
+            $tag = $this->tagFactory()->create();
             $tag->setTitle(ucfirst($slug))->setUrlKey('tag-list-' . $slug);
-            $this->repository->save($tag);
+            $this->repository()->save($tag);
         }
 
-        $criteria = $this->searchCriteriaBuilder
+        $criteria = $this->searchCriteriaBuilder()
             ->addFilter(TagInterface::URL_KEY, 'tag-list-%', 'like')
             ->create();
 
-        $results = $this->repository->getList($criteria);
+        $results = $this->repository()->getList($criteria);
         self::assertGreaterThanOrEqual(3, $results->getTotalCount());
     }
 
     public function test_get_by_id_throws_on_missing(): void
     {
         $this->expectException(NoSuchEntityException::class);
-        $this->repository->getById(9999999);
+        $this->repository()->getById(9999999);
+    }
+
+    private function repository(): TagRepositoryInterface
+    {
+        return Bootstrap::getObjectManager()->get(TagRepositoryInterface::class);
+    }
+
+    private function tagFactory(): TagInterfaceFactory
+    {
+        return Bootstrap::getObjectManager()->get(TagInterfaceFactory::class);
+    }
+
+    private function searchCriteriaBuilder(): SearchCriteriaBuilder
+    {
+        return Bootstrap::getObjectManager()->get(SearchCriteriaBuilder::class);
+    }
+
+    private function resource(): ResourceConnection
+    {
+        return Bootstrap::getObjectManager()->get(ResourceConnection::class);
     }
 }

--- a/Test/Integration/Model/UrlKeyGenerator/DbCollisionCheckerTest.php
+++ b/Test/Integration/Model/UrlKeyGenerator/DbCollisionCheckerTest.php
@@ -10,6 +10,10 @@ use MageOS\Blog\Api\UrlKeyGeneratorInterface;
 use MageOS\Blog\Model\UrlKeyGenerator\CollisionChecker;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @magentoAppArea adminhtml
+ * @magentoDbIsolation enabled
+ */
 final class DbCollisionCheckerTest extends TestCase
 {
     private CollisionChecker $checker;

--- a/Test/Integration/Model/UrlKeyGenerator/DbCollisionCheckerTest.php
+++ b/Test/Integration/Model/UrlKeyGenerator/DbCollisionCheckerTest.php
@@ -16,47 +16,37 @@ use PHPUnit\Framework\TestCase;
  */
 final class DbCollisionCheckerTest extends TestCase
 {
-    private CollisionChecker $checker;
-    private ResourceConnection $resource;
-
-    protected function setUp(): void
-    {
-        $objectManager = Bootstrap::getObjectManager();
-        $this->checker = $objectManager->get(CollisionChecker::class);
-        $this->resource = $objectManager->get(ResourceConnection::class);
-    }
-
     public function testIsTakenReturnsFalseWhenSlugIsAvailable(): void
     {
         self::assertFalse(
-            $this->checker->isTaken('totally-new-slug', UrlKeyGeneratorInterface::ENTITY_POST, null)
+            $this->checker()->isTaken('totally-new-slug', UrlKeyGeneratorInterface::ENTITY_POST, null)
         );
     }
 
     public function testIsTakenReturnsTrueWhenPostSlugExists(): void
     {
-        $connection = $this->resource->getConnection();
+        $connection = $this->resource()->getConnection();
         $connection->insert(
-            $this->resource->getTableName('mageos_blog_post'),
+            $this->resource()->getTableName('mageos_blog_post'),
             ['url_key' => 'existing-post', 'title' => 'Existing']
         );
 
         self::assertTrue(
-            $this->checker->isTaken('existing-post', UrlKeyGeneratorInterface::ENTITY_POST, null)
+            $this->checker()->isTaken('existing-post', UrlKeyGeneratorInterface::ENTITY_POST, null)
         );
     }
 
     public function testIsTakenExcludesTheProvidedEntityId(): void
     {
-        $connection = $this->resource->getConnection();
+        $connection = $this->resource()->getConnection();
         $connection->insert(
-            $this->resource->getTableName('mageos_blog_post'),
+            $this->resource()->getTableName('mageos_blog_post'),
             ['url_key' => 'edit-me', 'title' => 'Edit Me']
         );
         $postId = (int) $connection->lastInsertId();
 
         self::assertFalse(
-            $this->checker->isTaken(
+            $this->checker()->isTaken(
                 'edit-me',
                 UrlKeyGeneratorInterface::ENTITY_POST,
                 null,
@@ -69,40 +59,50 @@ final class DbCollisionCheckerTest extends TestCase
     public function testIsTakenThrowsOnUnknownEntityType(): void
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->checker->isTaken('foo', 'widget', null);
+        $this->checker()->isTaken('foo', 'widget', null);
     }
 
     public function testIsTakenScopesByStoreIdForPost(): void
     {
-        $connection = $this->resource->getConnection();
+        $connection = $this->resource()->getConnection();
         $connection->insert(
-            $this->resource->getTableName('mageos_blog_post'),
+            $this->resource()->getTableName('mageos_blog_post'),
             ['url_key' => 'store-scoped', 'title' => 'Store Scoped']
         );
         $postId = (int) $connection->lastInsertId();
         $connection->insert(
-            $this->resource->getTableName('mageos_blog_post_store'),
+            $this->resource()->getTableName('mageos_blog_post_store'),
             ['post_id' => $postId, 'store_id' => 1]
         );
 
         self::assertTrue(
-            $this->checker->isTaken('store-scoped', UrlKeyGeneratorInterface::ENTITY_POST, 1)
+            $this->checker()->isTaken('store-scoped', UrlKeyGeneratorInterface::ENTITY_POST, 1)
         );
         self::assertFalse(
-            $this->checker->isTaken('store-scoped', UrlKeyGeneratorInterface::ENTITY_POST, 2)
+            $this->checker()->isTaken('store-scoped', UrlKeyGeneratorInterface::ENTITY_POST, 2)
         );
     }
 
     public function testIsTakenIgnoresStoreScopeForAuthor(): void
     {
-        $connection = $this->resource->getConnection();
+        $connection = $this->resource()->getConnection();
         $connection->insert(
-            $this->resource->getTableName('mageos_blog_author'),
+            $this->resource()->getTableName('mageos_blog_author'),
             ['slug' => 'the-author', 'name' => 'The Author']
         );
 
         self::assertTrue(
-            $this->checker->isTaken('the-author', UrlKeyGeneratorInterface::ENTITY_AUTHOR, 99)
+            $this->checker()->isTaken('the-author', UrlKeyGeneratorInterface::ENTITY_AUTHOR, 99)
         );
+    }
+
+    private function checker(): CollisionChecker
+    {
+        return Bootstrap::getObjectManager()->get(CollisionChecker::class);
+    }
+
+    private function resource(): ResourceConnection
+    {
+        return Bootstrap::getObjectManager()->get(ResourceConnection::class);
     }
 }

--- a/Test/Integration/Plugin/Repository/AuthorUrlRewritePluginTest.php
+++ b/Test/Integration/Plugin/Repository/AuthorUrlRewritePluginTest.php
@@ -11,6 +11,10 @@ use MageOS\Blog\Api\Data\AuthorInterfaceFactory;
 use MageOS\Blog\Model\Url\UrlRewriteBuilder;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @magentoAppArea adminhtml
+ * @magentoDbIsolation enabled
+ */
 final class AuthorUrlRewritePluginTest extends TestCase
 {
     private AuthorRepositoryInterface $repository;

--- a/Test/Integration/Plugin/Repository/AuthorUrlRewritePluginTest.php
+++ b/Test/Integration/Plugin/Repository/AuthorUrlRewritePluginTest.php
@@ -17,34 +17,37 @@ use PHPUnit\Framework\TestCase;
  */
 final class AuthorUrlRewritePluginTest extends TestCase
 {
-    private AuthorRepositoryInterface $repository;
-    private AuthorInterfaceFactory $authorFactory;
-    private ResourceConnection $resource;
-
-    protected function setUp(): void
-    {
-        $objectManager = Bootstrap::getObjectManager();
-        $this->repository = $objectManager->get(AuthorRepositoryInterface::class);
-        $this->authorFactory = $objectManager->get(AuthorInterfaceFactory::class);
-        $this->resource = $objectManager->get(ResourceConnection::class);
-    }
-
     public function test_save_creates_url_rewrite_row(): void
     {
-        $author = $this->authorFactory->create();
+        $author = $this->authorFactory()->create();
         $author->setName('Jane Doe')
             ->setSlug('jane-doe');
-        $saved = $this->repository->save($author);
+        $saved = $this->repository()->save($author);
 
-        $connection = $this->resource->getConnection();
+        $connection = $this->resource()->getConnection();
         $row = $connection->fetchRow(
             $connection->select()
-                ->from($this->resource->getTableName('url_rewrite'))
+                ->from($this->resource()->getTableName('url_rewrite'))
                 ->where('entity_type = ?', UrlRewriteBuilder::ENTITY_TYPE_AUTHOR)
                 ->where('entity_id = ?', (int) $saved->getAuthorId())
         );
         self::assertNotEmpty($row);
         self::assertSame('blog/author/jane-doe', $row['request_path']);
         self::assertStringContainsString('blog/author/view/id/', $row['target_path']);
+    }
+
+    private function repository(): AuthorRepositoryInterface
+    {
+        return Bootstrap::getObjectManager()->get(AuthorRepositoryInterface::class);
+    }
+
+    private function authorFactory(): AuthorInterfaceFactory
+    {
+        return Bootstrap::getObjectManager()->get(AuthorInterfaceFactory::class);
+    }
+
+    private function resource(): ResourceConnection
+    {
+        return Bootstrap::getObjectManager()->get(ResourceConnection::class);
     }
 }

--- a/Test/Integration/Plugin/Repository/CategoryUrlRewritePluginTest.php
+++ b/Test/Integration/Plugin/Repository/CategoryUrlRewritePluginTest.php
@@ -11,6 +11,10 @@ use MageOS\Blog\Api\Data\CategoryInterfaceFactory;
 use MageOS\Blog\Model\Url\UrlRewriteBuilder;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @magentoAppArea adminhtml
+ * @magentoDbIsolation enabled
+ */
 final class CategoryUrlRewritePluginTest extends TestCase
 {
     private CategoryRepositoryInterface $repository;

--- a/Test/Integration/Plugin/Repository/CategoryUrlRewritePluginTest.php
+++ b/Test/Integration/Plugin/Repository/CategoryUrlRewritePluginTest.php
@@ -17,35 +17,38 @@ use PHPUnit\Framework\TestCase;
  */
 final class CategoryUrlRewritePluginTest extends TestCase
 {
-    private CategoryRepositoryInterface $repository;
-    private CategoryInterfaceFactory $categoryFactory;
-    private ResourceConnection $resource;
-
-    protected function setUp(): void
-    {
-        $objectManager = Bootstrap::getObjectManager();
-        $this->repository = $objectManager->get(CategoryRepositoryInterface::class);
-        $this->categoryFactory = $objectManager->get(CategoryInterfaceFactory::class);
-        $this->resource = $objectManager->get(ResourceConnection::class);
-    }
-
     public function test_save_creates_url_rewrite_row(): void
     {
-        $category = $this->categoryFactory->create();
+        $category = $this->categoryFactory()->create();
         $category->setTitle('News')
             ->setUrlKey('news')
             ->setStoreIds([1]);
-        $saved = $this->repository->save($category);
+        $saved = $this->repository()->save($category);
 
-        $connection = $this->resource->getConnection();
+        $connection = $this->resource()->getConnection();
         $row = $connection->fetchRow(
             $connection->select()
-                ->from($this->resource->getTableName('url_rewrite'))
+                ->from($this->resource()->getTableName('url_rewrite'))
                 ->where('entity_type = ?', UrlRewriteBuilder::ENTITY_TYPE_CATEGORY)
                 ->where('entity_id = ?', (int) $saved->getCategoryId())
         );
         self::assertNotEmpty($row);
         self::assertSame('blog/category/news', $row['request_path']);
         self::assertStringContainsString('blog/category/view/id/', $row['target_path']);
+    }
+
+    private function repository(): CategoryRepositoryInterface
+    {
+        return Bootstrap::getObjectManager()->get(CategoryRepositoryInterface::class);
+    }
+
+    private function categoryFactory(): CategoryInterfaceFactory
+    {
+        return Bootstrap::getObjectManager()->get(CategoryInterfaceFactory::class);
+    }
+
+    private function resource(): ResourceConnection
+    {
+        return Bootstrap::getObjectManager()->get(ResourceConnection::class);
     }
 }

--- a/Test/Integration/Plugin/Repository/PostUrlRewritePluginTest.php
+++ b/Test/Integration/Plugin/Repository/PostUrlRewritePluginTest.php
@@ -11,6 +11,10 @@ use MageOS\Blog\Api\PostRepositoryInterface;
 use MageOS\Blog\Model\Url\UrlRewriteBuilder;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @magentoAppArea adminhtml
+ * @magentoDbIsolation enabled
+ */
 final class PostUrlRewritePluginTest extends TestCase
 {
     private PostRepositoryInterface $repository;

--- a/Test/Integration/Plugin/Repository/PostUrlRewritePluginTest.php
+++ b/Test/Integration/Plugin/Repository/PostUrlRewritePluginTest.php
@@ -17,30 +17,18 @@ use PHPUnit\Framework\TestCase;
  */
 final class PostUrlRewritePluginTest extends TestCase
 {
-    private PostRepositoryInterface $repository;
-    private PostInterfaceFactory $postFactory;
-    private ResourceConnection $resource;
-
-    protected function setUp(): void
-    {
-        $objectManager = Bootstrap::getObjectManager();
-        $this->repository = $objectManager->get(PostRepositoryInterface::class);
-        $this->postFactory = $objectManager->get(PostInterfaceFactory::class);
-        $this->resource = $objectManager->get(ResourceConnection::class);
-    }
-
     public function test_save_creates_url_rewrite_row(): void
     {
-        $post = $this->postFactory->create();
+        $post = $this->postFactory()->create();
         $post->setTitle('Rewrite Test')
             ->setUrlKey('rewrite-test')
             ->setStoreIds([1]);
-        $saved = $this->repository->save($post);
+        $saved = $this->repository()->save($post);
 
-        $connection = $this->resource->getConnection();
+        $connection = $this->resource()->getConnection();
         $row = $connection->fetchRow(
             $connection->select()
-                ->from($this->resource->getTableName('url_rewrite'))
+                ->from($this->resource()->getTableName('url_rewrite'))
                 ->where('entity_type = ?', UrlRewriteBuilder::ENTITY_TYPE_POST)
                 ->where('entity_id = ?', (int) $saved->getPostId())
         );
@@ -51,19 +39,19 @@ final class PostUrlRewritePluginTest extends TestCase
 
     public function test_slug_change_produces_301_redirect(): void
     {
-        $post = $this->postFactory->create();
+        $post = $this->postFactory()->create();
         $post->setTitle('Original')
             ->setUrlKey('original-slug')
             ->setStoreIds([1]);
-        $saved = $this->repository->save($post);
+        $saved = $this->repository()->save($post);
 
         $saved->setUrlKey('new-slug');
-        $this->repository->save($saved);
+        $this->repository()->save($saved);
 
-        $connection = $this->resource->getConnection();
+        $connection = $this->resource()->getConnection();
         $redirectRow = $connection->fetchRow(
             $connection->select()
-                ->from($this->resource->getTableName('url_rewrite'))
+                ->from($this->resource()->getTableName('url_rewrite'))
                 ->where('entity_type = ?', UrlRewriteBuilder::ENTITY_TYPE_POST)
                 ->where('entity_id = ?', (int) $saved->getPostId())
                 ->where('request_path = ?', 'blog/original-slug')
@@ -74,22 +62,37 @@ final class PostUrlRewritePluginTest extends TestCase
 
     public function test_delete_removes_rewrite_rows(): void
     {
-        $post = $this->postFactory->create();
+        $post = $this->postFactory()->create();
         $post->setTitle('Doomed')
             ->setUrlKey('doomed')
             ->setStoreIds([1]);
-        $saved = $this->repository->save($post);
+        $saved = $this->repository()->save($post);
         $postId = (int) $saved->getPostId();
 
-        $this->repository->deleteById($postId);
+        $this->repository()->deleteById($postId);
 
-        $connection = $this->resource->getConnection();
+        $connection = $this->resource()->getConnection();
         $count = $connection->fetchOne(
             $connection->select()
-                ->from($this->resource->getTableName('url_rewrite'), ['COUNT(*)'])
+                ->from($this->resource()->getTableName('url_rewrite'), ['COUNT(*)'])
                 ->where('entity_type = ?', UrlRewriteBuilder::ENTITY_TYPE_POST)
                 ->where('entity_id = ?', $postId)
         );
         self::assertSame(0, (int) $count);
+    }
+
+    private function repository(): PostRepositoryInterface
+    {
+        return Bootstrap::getObjectManager()->get(PostRepositoryInterface::class);
+    }
+
+    private function postFactory(): PostInterfaceFactory
+    {
+        return Bootstrap::getObjectManager()->get(PostInterfaceFactory::class);
+    }
+
+    private function resource(): ResourceConnection
+    {
+        return Bootstrap::getObjectManager()->get(ResourceConnection::class);
     }
 }

--- a/Test/Integration/Plugin/Repository/TagUrlRewritePluginTest.php
+++ b/Test/Integration/Plugin/Repository/TagUrlRewritePluginTest.php
@@ -11,6 +11,10 @@ use MageOS\Blog\Api\TagRepositoryInterface;
 use MageOS\Blog\Model\Url\UrlRewriteBuilder;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @magentoAppArea adminhtml
+ * @magentoDbIsolation enabled
+ */
 final class TagUrlRewritePluginTest extends TestCase
 {
     private TagRepositoryInterface $repository;

--- a/Test/Integration/Plugin/Repository/TagUrlRewritePluginTest.php
+++ b/Test/Integration/Plugin/Repository/TagUrlRewritePluginTest.php
@@ -17,35 +17,38 @@ use PHPUnit\Framework\TestCase;
  */
 final class TagUrlRewritePluginTest extends TestCase
 {
-    private TagRepositoryInterface $repository;
-    private TagInterfaceFactory $tagFactory;
-    private ResourceConnection $resource;
-
-    protected function setUp(): void
-    {
-        $objectManager = Bootstrap::getObjectManager();
-        $this->repository = $objectManager->get(TagRepositoryInterface::class);
-        $this->tagFactory = $objectManager->get(TagInterfaceFactory::class);
-        $this->resource = $objectManager->get(ResourceConnection::class);
-    }
-
     public function test_save_creates_url_rewrite_row(): void
     {
-        $tag = $this->tagFactory->create();
+        $tag = $this->tagFactory()->create();
         $tag->setTitle('Magento')
             ->setUrlKey('magento')
             ->setStoreIds([1]);
-        $saved = $this->repository->save($tag);
+        $saved = $this->repository()->save($tag);
 
-        $connection = $this->resource->getConnection();
+        $connection = $this->resource()->getConnection();
         $row = $connection->fetchRow(
             $connection->select()
-                ->from($this->resource->getTableName('url_rewrite'))
+                ->from($this->resource()->getTableName('url_rewrite'))
                 ->where('entity_type = ?', UrlRewriteBuilder::ENTITY_TYPE_TAG)
                 ->where('entity_id = ?', (int) $saved->getTagId())
         );
         self::assertNotEmpty($row);
         self::assertSame('blog/tag/magento', $row['request_path']);
         self::assertStringContainsString('blog/tag/view/id/', $row['target_path']);
+    }
+
+    private function repository(): TagRepositoryInterface
+    {
+        return Bootstrap::getObjectManager()->get(TagRepositoryInterface::class);
+    }
+
+    private function tagFactory(): TagInterfaceFactory
+    {
+        return Bootstrap::getObjectManager()->get(TagInterfaceFactory::class);
+    }
+
+    private function resource(): ResourceConnection
+    {
+        return Bootstrap::getObjectManager()->get(ResourceConnection::class);
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "magento/module-widget": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "^10.5",
+        "phpunit/phpunit": "^12.5",
         "phpstan/phpstan": "^2.0",
         "bitexpert/phpstan-magento": "^0.42",
         "friendsofphp/php-cs-fixer": "^3.50",
@@ -58,7 +58,7 @@
     "scripts": {
         "test:unit":      "phpunit -c phpunit.xml.dist --testsuite unit",
         "test:phpstan":   "phpstan analyse --memory-limit=1G",
-        "test:cs-fixer":  "php-cs-fixer fix --dry-run --diff",
+        "test:cs-fixer":  "php-cs-fixer fix --dry-run --allow-risky=yes --diff",
         "test:phpcs":     "phpcs --standard=phpcs.xml.dist",
         "test:infection": "infection --min-msi=75 --threads=4",
         "test":           ["@test:unit", "@test:phpstan", "@test:cs-fixer", "@test:phpcs"]


### PR DESCRIPTION
<!--
Thanks for opening a pull request. A short summary plus the checklist below keeps reviews fast.
-->

## Summary

<!-- What does this PR do? 2-3 bullets is plenty. -->

- Fixes the integration tests to stop the errors
- Updates tests to use the area annotations can loads the requirements differently.

## Motivation

<!-- Why is the change needed? Link the related issue: Closes #123. -->
Fixes Errors for #6 

Closes #

## How to test

<!-- Step-by-step, or "run phpunit" if purely internal. -->

1. Run the actions for #6 
2. 

## Checklist

- [x] Branch is based on the latest `main`.
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `refactor:`, `test:`, `chore:`, `docs:`).
- [x] `vendor/bin/phpunit --testsuite unit` passes locally.
- [x] `vendor/bin/phpstan analyse --memory-limit=1G` passes locally.
- [x] `vendor/bin/phpcs --standard=phpcs.xml.dist` passes locally.
- [x] `vendor/bin/php-cs-fixer fix --dry-run --diff --allow-risky=yes` shows no changes needed.
- [x] New PHP files start with `declare(strict_types=1);`.
- [x] User-facing change has a `CHANGELOG.md` entry under `## [Unreleased]`.
- [x] No raw integer IDs in admin UX (use pickers / linked names. See `CONTRIBUTING.md`).

## Screenshots / GraphQL samples (if UI or API change)

<!-- Drag screenshots here, or paste a sample query + response. -->
